### PR TITLE
fix:check input values to avoid zero million or impossible values

### DIFF
--- a/app/src/main/java/com/forz/calculator/fragments/MainFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/MainFragment.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -176,6 +178,16 @@ class MainFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/forz/calculator/fragments/land/MainLandFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/land/MainLandFragment.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -146,6 +148,16 @@ class MainLandFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/forz/calculator/fragments/largeLand/LargeLandFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/largeLand/LargeLandFragment.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -142,6 +144,16 @@ class LargeLandFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/forz/calculator/fragments/small/SmallFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/small/SmallFragment.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -180,6 +182,16 @@ class SmallFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/forz/calculator/fragments/smallLand/SmallLandFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/smallLand/SmallLandFragment.kt
@@ -2,6 +2,8 @@ package com.forz.calculator.fragments.smallLand
 
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -80,6 +82,16 @@ class SmallLandFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {

--- a/app/src/main/java/com/forz/calculator/fragments/xLargeLand/XLargeLandFragment.kt
+++ b/app/src/main/java/com/forz/calculator/fragments/xLargeLand/XLargeLandFragment.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -141,6 +143,16 @@ class XLargeLandFragment : Fragment(),
                 view.requestFocus()
             }
         }
+
+        binding.expressionEditText.filters = arrayOf(object : InputFilter {
+            override fun filter(source: CharSequence?, start: Int, end: Int,
+                                dest: Spanned?, dstart: Int, dend: Int
+            ): CharSequence? {
+                val result = dest.toString().substring(0, dstart) + source?.subSequence(start, end) + dest.toString().substring(dend)
+                val findPattern = Regex("^0[0-9]")
+                return if(findPattern.find(result) != null) "" else null
+            }
+        })
 
         binding.expressionEditText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {


### PR DESCRIPTION
problem: there is no check with input value. for example, user can input 00,012,00000012, like these impossible values.

solution: add check when there is a change of text, if it's first two characters are match 0[0-9],the input will be rejected, means it will keep "0" instead of "00".

Fixes #41